### PR TITLE
Adds more Python3 compatibility

### DIFF
--- a/classification/common.py
+++ b/classification/common.py
@@ -5,7 +5,10 @@ import numpy as np
 from scipy.optimize import leastsq
 import os
 from PIL import Image
-import least_squares_circle
+try:
+    import least_squares_circle
+except ImportError:
+    from . import least_squares_circle
 
 def distance(point1, point2):
     # Simple 2D distance function using Pythagoras:

--- a/classification/lucid_algorithm.py
+++ b/classification/lucid_algorithm.py
@@ -8,7 +8,10 @@
 # for generating counts for mapping with LUCID data.
 # TODO develop separate modes for lower 'agression' settings
 
-import common
+try:
+    import common
+except ImportError:
+    from . import common
 
 class Blob(common.Blob):
     def classify(self, mode):

--- a/classification/old_algorithm.py
+++ b/classification/old_algorithm.py
@@ -8,7 +8,10 @@ from scipy.optimize import leastsq
 import json
 import os
 from collections import OrderedDict
-import common
+try:
+    import common
+except ImportError:
+    from . import common
 
 # Load up the types file
 types = json.loads(open(os.path.dirname(os.path.realpath(__file__)) + "/types/old_algorithm.json").read())
@@ -24,12 +27,12 @@ class Blob(common.Blob):
                         "density": self.density,
                         "squiggliness": self.squiggliness}
         # Loop through each potential particle type, looking for a match
-        for particle_name, subtypes in types.iteritems():
-            for name, properties in subtypes.iteritems():
+        for particle_name, subtypes in types.items():
+            for name, properties in subtypes.items():
                 # Initially, presume the particle is a match
                 match = True
                 # Check through each property, in the form {name: (lower_bound, upper_bound)}
-                for property_name, property_value in properties.iteritems():
+                for property_name, property_value in properties.items():
                     # If the blob's properties lie outside the bounds specified in the types file, the blob is not a match
                     if (blob_values[property_name] < property_value[0]) or (blob_values[property_name] > property_value[1]):
                         match = False


### PR DESCRIPTION
Some small changes to allow it to run via Python 3.

These shouldn't affect Python 2 functionality, although using items vs. iteritems in Python 2 could have some efficiency implications. However, based on the number of items in that JSON file I presume it wouldn't be a heavy hit. 

viewitems() could be used instead, backported from 3 - but that isn't in 2.6 - which means we wouldn't be able to use it on GridPP :(
